### PR TITLE
Apply transforms to inspections output

### DIFF
--- a/src/inspections/inspections.ts
+++ b/src/inspections/inspections.ts
@@ -85,6 +85,12 @@ export const Inspections = (customFolderResources: customFolderResource[] | null
 
 	console.log(inspections)
 
+	// computed .map, .filter etc. transforms
+	// make inspections data-driven as possible for 'pure' ui (render data only, no transforms)
+	const output = {
+		latest_version: inspections.find(i => i.inspection === 'latest_version'),
+	}
+
 	return inspections
 }
 


### PR DESCRIPTION
For avoiding code like:
https://github.com/mazatf2/unofficial-mastercomfig-installer/blob/d1a3971fa46eda8086a5f39abe526e742831b612/src/components/ResourceList/ResourceListItem.tsx#L26

on render time.